### PR TITLE
CI: pin GitHub Actions workflows

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,7 +27,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5
 
       - name: Install free-pascal compiler and lazarus
         run: |
@@ -39,7 +39,7 @@ jobs:
         run: bin/test
 
       - name: Report
-        uses: dorny/test-reporter@v1
+        uses: dorny/test-reporter@
         if: always()
         with:
           name: Junit Test Results

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,7 +39,7 @@ jobs:
         run: bin/test
 
       - name: Report
-        uses: dorny/test-reporter@
+        uses: dorny/test-reporter@afe6793191b75b608954023a46831a3fe10048d4
         if: always()
         with:
           name: Junit Test Results


### PR DESCRIPTION
This PR updates GitHub Actions workflows to a specific version.
This ensures that the workflow will always run the same code, which makes your build _stable_.
It will also prevent a potential security issue where a tag could be replaced by a malicious commit without consumers being aware of it.

The PR updates each non-SHA based workflow reference with the SHA of the referenced version/tag, so the current behavior should not change.

See https://exercism.org/docs/building/github/gha-best-practices#h-pin-actions-to-shas for more information.