### PR TITLE
Group all GitHub Actions updates into a single larger pull request

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,5 +5,9 @@ updates:
   # Keep dependencies for GitHub Actions up-to-date
   - package-ecosystem: 'github-actions'
     directory: '/'
+    groups:
+      github-actions:
+        patterns:
+          - "*"  # Group all Actions updates into a single larger pull request
     schedule:
       interval: 'monthly'


### PR DESCRIPTION
https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#groups--

Reduces the number of pull requests to review and voids blockages like:
* #23 vs.
* #27 vs.
* #28 by putting them all in a single pull request