### PR TITLE
Add run-configlet-sync workflow

### DIFF
--- a/.github/workflows/run-configlet-sync.yml
+++ b/.github/workflows/run-configlet-sync.yml
@@ -1,0 +1,10 @@
+name: Run Configlet Sync
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 0 2 * *'
+
+jobs:
+  call-gha-workflow:
+    uses: exercism/github-actions/.github/workflows/configlet-sync.yml@main


### PR DESCRIPTION
Various tracks are finding this helpful.
[Forum discussion](https://forum.exercism.org/t/automating-syncing-with-github-actions-final-testing-going-on-for-java-track-open-to-more-tracks/17807)

An example of the PR it automatically creates if there are instruction edits to sync: exercism/lua#619

An example of the issue it automatically creates if there are new test cases to add: exercism/lua#604