### PR TITLE
Format all `instructions.append.md` to start with an H1 (required but ignored) and H2

### DIFF
--- a/exercises/practice/leap/.docs/instructions.append.md
+++ b/exercises/practice/leap/.docs/instructions.append.md
@@ -1,4 +1,6 @@
-# Hints
+# Instructions append
+
+## Hints
 
 Assign the value of an [expression] to `result` to complete this exercise.
 

--- a/exercises/practice/queen-attack/.docs/instructions.append.md
+++ b/exercises/practice/queen-attack/.docs/instructions.append.md
@@ -1,6 +1,10 @@
 # Instructions append
 
-The queens shown below are at their [default starting positions](https://en.wikipedia.org/wiki/Rules_of_chess#Initial_setup). That's the 1st rank (row 7) for the white queen and the 8th rank (row 0) for the black queen. Both queens start in the d file (column 3).
+## Implementation
+
+The queens shown below are at their [default starting positions](https://en.wikipedia.org/wiki/Rules_of_chess#Initial_setup).
+That's the 1st rank (row 7) for the white queen and the 8th rank (row 0) for the black queen.
+Both queens start in the d file (column 3).
 
 ```text
   a b c d e f g h


### PR DESCRIPTION
See related discussions [here](https://forum.exercism.org/t/grep-instructions-append-may-need-a-visible-header/53923) as well as https://github.com/exercism/docs/pull/592. Append files should all have an H1. Including an H2 helps break the flow from the non-append file to the append file so it does not read as the same stream of thought.